### PR TITLE
I thought this was a good idea because the graph edges may have been initialized BEFORE it's passed into the dataloader, but it's actually done AFTER

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,7 @@
             "args": [
                 "--num_timesteps=100",
                 "--gpus=0", // force it to use cpu (for development)
+                "--radius=5"
             ],
         }
     ]


### PR DESCRIPTION
not using since I found a decent workaround where we perturb the inputs in the loss function