### PR TITLE
generates in parallel

### DIFF
--- a/diffusion/inference/create_gif.py
+++ b/diffusion/inference/create_gif.py
@@ -7,8 +7,8 @@ ImageFile.LOAD_TRUNCATED_IMAGES = True
 def generate_gif(src_img_dir: str, output_file: str, duration_ms: int = 100):
     image_files = glob.glob(os.path.join(src_img_dir, "*.png"))
 
-    # Sort the image files by creation time (ascending order)
-    image_files.sort(key=os.path.getctime)
+    # Sort the image files by name (descending order)
+    image_files.sort(key=lambda x: os.path.basename(x), reverse=True)
     
     # Open the first image
     first_image = Image.open(image_files[0])


### PR DESCRIPTION
This PR generates the diffusion step images in parallel.
- However, I don't think the bottleneck is generating the images. it's more running the model. so this parallelization doesn't really speedup