### PR TITLE
Variance preserving frac coord diffusion

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -52,7 +52,7 @@
             "console": "integratedTerminal",
             "justMyCode": true,
             "args": [
-                "--model_path=models/pred-lattice-as-well.ckpt",
+                "--model_path=models/variance-preserving-frac-coord-diffusion.ckpt",
             ],
         },
         {


### PR DESCRIPTION
- the main things:
- 1) we switched from variance exploding to variance preserving diffusion for the positions
- 2) rather than diffusing hte cartesian coords, we diffuse the fractional coords
- THIS BRANCH DOESN'T HAVE MEMORY LEAKS!
- maybe tis' the variance exploding module that leaks memory
- Note: after training all night, the generated crystals don't look like real carbon crystals that could exist
-