### PR TITLE
fix batch index when generating mass number of samples

### DIFF
--- a/diffusion/diffusion_loss.py
+++ b/diffusion/diffusion_loss.py
@@ -343,7 +343,9 @@ class DiffusionLoss(torch.nn.Module):
                     model,
                     Batch(
                         num_atoms=num_atoms,
-                        batch=torch.tensor(0).repeat(num_atoms.sum()),
+                        batch=torch.arange(0, num_samples_in_batch).repeat_interleave(
+                            num_atoms_per_sample
+                        ),
                     ),
                     t_emb_weights,
                 )

--- a/exploration/view_generated_results.ipynb
+++ b/exploration/view_generated_results.ipynb
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,33 +83,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        <iframe\n",
-       "            width=\"100%\"\n",
-       "            height=\"650\"\n",
-       "            src=\"http://127.0.0.1:8884/\"\n",
-       "            frameborder=\"0\"\n",
-       "            allowfullscreen\n",
-       "            \n",
-       "        ></iframe>\n",
-       "        "
-      ],
-      "text/plain": [
-       "<IPython.lib.display.IFrame at 0x2bd080490>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "show_crystal(0)"
    ]


### PR DESCRIPTION
- we weren't properly calculating the batch index when generating multiple samples at once, leading to lattices that were extremely skewed