### PR TITLE
remove self edges

### DIFF
--- a/diffusion/diffusion_loss.py
+++ b/diffusion/diffusion_loss.py
@@ -160,7 +160,7 @@ class DiffusionLoss(torch.nn.Module):
                 self.cutoff,
                 self.max_neighbors,
                 device=cart_x_t.device,
-                remove_self_edges=True,  # so we can have self-interactions. This feels important because how else will we incorporate data about our current node from the previous layer?
+                remove_self_edges=True,  # Removing self-loops since the embedding after message passing is also dependent on the embedding of the current node. see https://github.com/curtischong/arreau/pull/97 for details
             )
         )
         batch.edge_index = edge_index


### PR DESCRIPTION
- The loss was slightly higher. But it was so minuscule, it could be noise
- so self-edges does help a bit
- Note: the number of neighbors stayed the same
- I'm probably going to keep self loops in because ponita uses self loops

UPDATE: I am deciding to merge this because I read the code and realized that the model already incorporates
the embedding from BEFORE message passing back into the embedding AFTER message passing. (this is essentially a self-loop)
- https://github.com/curtischong/arreau/blob/main/ponita/nn/convnext.py#L32
- If I REALLY wanted to remove self-loops I'll remove this as well. but as it stands, removing self edges seems correct since it's technically incorporated (especially since mofdiff doesn't calculate self-loops when passing to gemnet)